### PR TITLE
enabled auto-geolocation

### DIFF
--- a/Mixpanel/Mixpanel.swift
+++ b/Mixpanel/Mixpanel.swift
@@ -132,7 +132,7 @@ public struct Mixpanel {
 		do {
 			let json = try NSJSONSerialization.dataWithJSONObject(payload, options: [])
 			let base64 = json.base64EncodedStringWithOptions([]).stringByReplacingOccurrencesOfString("\n", withString: "")
-			if let url = NSURL(string: "\(endpoint)?data=\(base64)") {
+			if let url = NSURL(string: "\(endpoint)?data=\(base64)&ip=1") {
 				URLSession.dataTaskWithRequest(NSURLRequest(URL: url), completionHandler: { data, _, error in
 					if error != nil {
 						completion?(success: false)


### PR DESCRIPTION
Allow Mixpanel to automatically determine geolocation by IP.

PS. Sorry for the previous pull request, it seems that GitHub Desktop is definitely not ready for prime-time.
