### PR TITLE
Add Mixpanel People API

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "venmo/DVR" "v0.1.2"
+github "venmo/DVR" "v0.3.0"

--- a/Mixpanel.xcodeproj/project.pbxproj
+++ b/Mixpanel.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		2126B6231B9F940000352016 /* tracking.json in Resources */ = {isa = PBXBuildFile; fileRef = 2126B6201B9F93FB00352016 /* tracking.json */; };
 		2126B6251B9F942500352016 /* tracking-parameters.json in Resources */ = {isa = PBXBuildFile; fileRef = 2126B6241B9F942500352016 /* tracking-parameters.json */; };
 		2126B6261B9F942500352016 /* tracking-parameters.json in Resources */ = {isa = PBXBuildFile; fileRef = 2126B6241B9F942500352016 /* tracking-parameters.json */; };
+		F9D660E51CB2ECA2003B6232 /* people-set.json in Resources */ = {isa = PBXBuildFile; fileRef = F9D660E11CB2EC92003B6232 /* people-set.json */; };
+		F9D660E61CB2ECA3003B6232 /* people-set.json in Resources */ = {isa = PBXBuildFile; fileRef = F9D660E11CB2EC92003B6232 /* people-set.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -84,6 +86,7 @@
 		210B32961B37DF42005F43F3 /* DVR.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DVR.framework; path = Carthage/Build/iOS/DVR.framework; sourceTree = "<group>"; };
 		2126B6201B9F93FB00352016 /* tracking.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = tracking.json; sourceTree = "<group>"; };
 		2126B6241B9F942500352016 /* tracking-parameters.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "tracking-parameters.json"; sourceTree = "<group>"; };
+		F9D660E11CB2EC92003B6232 /* people-set.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "people-set.json"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -201,6 +204,7 @@
 			children = (
 				2126B6201B9F93FB00352016 /* tracking.json */,
 				2126B6241B9F942500352016 /* tracking-parameters.json */,
+				F9D660E11CB2EC92003B6232 /* people-set.json */,
 			);
 			path = Fixtures;
 			sourceTree = "<group>";
@@ -387,6 +391,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F9D660E51CB2ECA2003B6232 /* people-set.json in Resources */,
 				2126B6251B9F942500352016 /* tracking-parameters.json in Resources */,
 				2126B6221B9F93FF00352016 /* tracking.json in Resources */,
 			);
@@ -403,6 +408,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F9D660E61CB2ECA3003B6232 /* people-set.json in Resources */,
 				2126B6261B9F942500352016 /* tracking-parameters.json in Resources */,
 				2126B6231B9F940000352016 /* tracking.json in Resources */,
 			);

--- a/Mixpanel/Tests/Fixtures/people-set.json
+++ b/Mixpanel/Tests/Fixtures/people-set.json
@@ -1,0 +1,29 @@
+{
+  "interactions" : [
+    {
+      "recorded_at" : 1459795131.008461,
+      "response" : {
+        "status" : 200,
+        "url" : "https:\/\/api.mixpanel.com\/engage\/?data=eyIkZGlzdGluY3RfaWQiOiIxIiwiJHNldCI6eyIkZW1haWwiOiJleGFtcGxldXNlckBleGFtcGxlLmNvbSIsIiRuYW1lIjoiRXhhbXBsZSBVc2VyIn0sIiR0b2tlbiI6IjA3ZTYwYzE1YzI2MzBkOTA0N2Q2MmFjNzc5MjAzY2FlIn0=",
+        "headers" : {
+          "Server" : "nginx\/1.9.12",
+          "Content-Type" : "application\/json",
+          "Access-Control-Allow-Origin" : "*",
+          "Access-Control-Allow-Methods" : "GET, POST, OPTIONS",
+          "Access-Control-Allow-Credentials" : "true",
+          "Access-Control-Max-Age" : "1728000",
+          "Date" : "Mon, 04 Apr 2016 18:38:50 GMT",
+          "Access-Control-Allow-Headers" : "X-Requested-With",
+          "Content-Length" : "1",
+          "Cache-Control" : "no-cache, no-store",
+          "Connection" : "keep-alive"
+        }
+      },
+      "request" : {
+        "method" : "GET",
+        "url" : "https:\/\/api.mixpanel.com\/engage\/?data=eyIkZGlzdGluY3RfaWQiOiIxIiwiJHNldCI6eyIkZW1haWwiOiJleGFtcGxldXNlckBleGFtcGxlLmNvbSIsIiRuYW1lIjoiRXhhbXBsZSBVc2VyIn0sIiR0b2tlbiI6IjA3ZTYwYzE1YzI2MzBkOTA0N2Q2MmFjNzc5MjAzY2FlIn0="
+      }
+    }
+  ],
+  "name" : "people-set"
+}

--- a/Mixpanel/Tests/Fixtures/tracking-parameters.json
+++ b/Mixpanel/Tests/Fixtures/tracking-parameters.json
@@ -1,18 +1,18 @@
 {
   "interactions" : [
     {
-      "recorded_at" : 1441750147.001717,
+      "recorded_at" : 1459778709.117311,
       "response" : {
         "status" : 200,
-        "url" : "https:\/\/api.mixpanel.com\/track\/?data=eyJldmVudCI6InRlc3QyIiwicHJvcGVydGllcyI6eyIkbW9kZWwiOiJ4ODZfNjQiLCJmb28iOiJiYXIiLCIkbWFudWZhY3R1cmVyIjoiQXBwbGUiLCJ0b2tlbiI6IjA3ZTYwYzE1YzI2MzBkOTA0N2Q2MmFjNzc5MjAzY2FlIiwidGltZSI6MTQzNDk1NDk3NCwiJHNjcmVlbl9oZWlnaHQiOjY2NywiJHNjcmVlbl93aWR0aCI6Mzc1LCIkb3MiOiJpUGhvbmUgT1MiLCIkb3NfdmVyc2lvbiI6IjkuMCIsIm1wX2xpYiI6ImlwaG9uZSJ9fQ==&ip=1",
+        "url" : "https:\/\/api.mixpanel.com\/track\/?data=eyJldmVudCI6InRlc3QyIiwicHJvcGVydGllcyI6eyIkbW9kZWwiOiJ4ODZfNjQiLCJmb28iOiJiYXIiLCIkbWFudWZhY3R1cmVyIjoiQXBwbGUiLCJ0b2tlbiI6IjA3ZTYwYzE1YzI2MzBkOTA0N2Q2MmFjNzc5MjAzY2FlIiwidGltZSI6MTQzNDk1NDk3NCwiJHNjcmVlbl9oZWlnaHQiOjY2NywiJHNjcmVlbl93aWR0aCI6Mzc1LCIkb3MiOiJpUGhvbmUgT1MiLCIkb3NfdmVyc2lvbiI6IjkuMyIsIm1wX2xpYiI6ImlwaG9uZSJ9fQ==&ip=1",
         "headers" : {
-          "Server" : "nginx\/1.9.1",
+          "Server" : "nginx\/1.9.12",
           "Content-Type" : "application\/json",
           "Access-Control-Allow-Origin" : "*",
           "Access-Control-Allow-Methods" : "GET, POST, OPTIONS",
           "Access-Control-Allow-Credentials" : "true",
           "Access-Control-Max-Age" : "1728000",
-          "Date" : "Tue, 08 Sep 2015 22:09:06 GMT",
+          "Date" : "Mon, 04 Apr 2016 14:05:09 GMT",
           "Access-Control-Allow-Headers" : "X-Requested-With",
           "Content-Length" : "1",
           "Cache-Control" : "no-cache, no-store",
@@ -21,7 +21,7 @@
       },
       "request" : {
         "method" : "GET",
-        "url" : "https:\/\/api.mixpanel.com\/track\/?data=eyJldmVudCI6InRlc3QyIiwicHJvcGVydGllcyI6eyIkbW9kZWwiOiJ4ODZfNjQiLCJmb28iOiJiYXIiLCIkbWFudWZhY3R1cmVyIjoiQXBwbGUiLCJ0b2tlbiI6IjA3ZTYwYzE1YzI2MzBkOTA0N2Q2MmFjNzc5MjAzY2FlIiwidGltZSI6MTQzNDk1NDk3NCwiJHNjcmVlbl9oZWlnaHQiOjY2NywiJHNjcmVlbl93aWR0aCI6Mzc1LCIkb3MiOiJpUGhvbmUgT1MiLCIkb3NfdmVyc2lvbiI6IjkuMCIsIm1wX2xpYiI6ImlwaG9uZSJ9fQ==&ip=1"
+        "url" : "https:\/\/api.mixpanel.com\/track\/?data=eyJldmVudCI6InRlc3QyIiwicHJvcGVydGllcyI6eyIkbW9kZWwiOiJ4ODZfNjQiLCJmb28iOiJiYXIiLCIkbWFudWZhY3R1cmVyIjoiQXBwbGUiLCJ0b2tlbiI6IjA3ZTYwYzE1YzI2MzBkOTA0N2Q2MmFjNzc5MjAzY2FlIiwidGltZSI6MTQzNDk1NDk3NCwiJHNjcmVlbl9oZWlnaHQiOjY2NywiJHNjcmVlbl93aWR0aCI6Mzc1LCIkb3MiOiJpUGhvbmUgT1MiLCIkb3NfdmVyc2lvbiI6IjkuMyIsIm1wX2xpYiI6ImlwaG9uZSJ9fQ==&ip=1"
       }
     }
   ],

--- a/Mixpanel/Tests/Fixtures/tracking-parameters.json
+++ b/Mixpanel/Tests/Fixtures/tracking-parameters.json
@@ -1,10 +1,10 @@
 {
   "interactions" : [
     {
-      "recorded_at" : 1459778709.117311,
+      "recorded_at" : 1459797457.070039,
       "response" : {
         "status" : 200,
-        "url" : "https:\/\/api.mixpanel.com\/track\/?data=eyJldmVudCI6InRlc3QyIiwicHJvcGVydGllcyI6eyIkbW9kZWwiOiJ4ODZfNjQiLCJmb28iOiJiYXIiLCIkbWFudWZhY3R1cmVyIjoiQXBwbGUiLCJ0b2tlbiI6IjA3ZTYwYzE1YzI2MzBkOTA0N2Q2MmFjNzc5MjAzY2FlIiwidGltZSI6MTQzNDk1NDk3NCwiJHNjcmVlbl9oZWlnaHQiOjY2NywiJHNjcmVlbl93aWR0aCI6Mzc1LCIkb3MiOiJpUGhvbmUgT1MiLCIkb3NfdmVyc2lvbiI6IjkuMyIsIm1wX2xpYiI6ImlwaG9uZSJ9fQ==&ip=1",
+        "url" : "https:\/\/api.mixpanel.com\/track\/?data=eyJwcm9wZXJ0aWVzIjp7IiRtb2RlbCI6Ing4Nl82NCIsImZvbyI6ImJhciIsIiRtYW51ZmFjdHVyZXIiOiJBcHBsZSIsInRva2VuIjoiMDdlNjBjMTVjMjYzMGQ5MDQ3ZDYyYWM3NzkyMDNjYWUiLCJ0aW1lIjoxNDM0OTU0OTc0LCIkc2NyZWVuX2hlaWdodCI6NjY3LCIkc2NyZWVuX3dpZHRoIjozNzUsIiRvcyI6ImlQaG9uZSBPUyIsIiRvc192ZXJzaW9uIjoiOS4zIiwibXBfbGliIjoiaXBob25lIn0sImV2ZW50IjoidGVzdDIifQ==&ip=1",
         "headers" : {
           "Server" : "nginx\/1.9.12",
           "Content-Type" : "application\/json",
@@ -12,7 +12,7 @@
           "Access-Control-Allow-Methods" : "GET, POST, OPTIONS",
           "Access-Control-Allow-Credentials" : "true",
           "Access-Control-Max-Age" : "1728000",
-          "Date" : "Mon, 04 Apr 2016 14:05:09 GMT",
+          "Date" : "Mon, 04 Apr 2016 19:17:37 GMT",
           "Access-Control-Allow-Headers" : "X-Requested-With",
           "Content-Length" : "1",
           "Cache-Control" : "no-cache, no-store",
@@ -21,7 +21,7 @@
       },
       "request" : {
         "method" : "GET",
-        "url" : "https:\/\/api.mixpanel.com\/track\/?data=eyJldmVudCI6InRlc3QyIiwicHJvcGVydGllcyI6eyIkbW9kZWwiOiJ4ODZfNjQiLCJmb28iOiJiYXIiLCIkbWFudWZhY3R1cmVyIjoiQXBwbGUiLCJ0b2tlbiI6IjA3ZTYwYzE1YzI2MzBkOTA0N2Q2MmFjNzc5MjAzY2FlIiwidGltZSI6MTQzNDk1NDk3NCwiJHNjcmVlbl9oZWlnaHQiOjY2NywiJHNjcmVlbl93aWR0aCI6Mzc1LCIkb3MiOiJpUGhvbmUgT1MiLCIkb3NfdmVyc2lvbiI6IjkuMyIsIm1wX2xpYiI6ImlwaG9uZSJ9fQ==&ip=1"
+        "url" : "https:\/\/api.mixpanel.com\/track\/?data=eyJwcm9wZXJ0aWVzIjp7IiRtb2RlbCI6Ing4Nl82NCIsImZvbyI6ImJhciIsIiRtYW51ZmFjdHVyZXIiOiJBcHBsZSIsInRva2VuIjoiMDdlNjBjMTVjMjYzMGQ5MDQ3ZDYyYWM3NzkyMDNjYWUiLCJ0aW1lIjoxNDM0OTU0OTc0LCIkc2NyZWVuX2hlaWdodCI6NjY3LCIkc2NyZWVuX3dpZHRoIjozNzUsIiRvcyI6ImlQaG9uZSBPUyIsIiRvc192ZXJzaW9uIjoiOS4zIiwibXBfbGliIjoiaXBob25lIn0sImV2ZW50IjoidGVzdDIifQ==&ip=1"
       }
     }
   ],

--- a/Mixpanel/Tests/Fixtures/tracking.json
+++ b/Mixpanel/Tests/Fixtures/tracking.json
@@ -1,10 +1,10 @@
 {
   "interactions" : [
     {
-      "recorded_at" : 1459778610.240579,
+      "recorded_at" : 1459797361.947727,
       "response" : {
         "status" : 200,
-        "url" : "https:\/\/api.mixpanel.com\/track\/?data=eyJldmVudCI6InRlc3QxIiwicHJvcGVydGllcyI6eyIkbW9kZWwiOiJ4ODZfNjQiLCIkbWFudWZhY3R1cmVyIjoiQXBwbGUiLCJ0b2tlbiI6IjA3ZTYwYzE1YzI2MzBkOTA0N2Q2MmFjNzc5MjAzY2FlIiwidGltZSI6MTQzNDk1NDk3NCwiJHNjcmVlbl9oZWlnaHQiOjY2NywiJHNjcmVlbl93aWR0aCI6Mzc1LCIkb3MiOiJpUGhvbmUgT1MiLCIkb3NfdmVyc2lvbiI6IjkuMyIsIm1wX2xpYiI6ImlwaG9uZSJ9fQ==&ip=1",
+        "url" : "https:\/\/api.mixpanel.com\/track\/?data=eyJwcm9wZXJ0aWVzIjp7IiRtb2RlbCI6Ing4Nl82NCIsIiRtYW51ZmFjdHVyZXIiOiJBcHBsZSIsInRva2VuIjoiMDdlNjBjMTVjMjYzMGQ5MDQ3ZDYyYWM3NzkyMDNjYWUiLCJ0aW1lIjoxNDM0OTU0OTc0LCIkc2NyZWVuX2hlaWdodCI6NjY3LCIkc2NyZWVuX3dpZHRoIjozNzUsIiRvcyI6ImlQaG9uZSBPUyIsIiRvc192ZXJzaW9uIjoiOS4zIiwibXBfbGliIjoiaXBob25lIn0sImV2ZW50IjoidGVzdDEifQ==&ip=1",
         "headers" : {
           "Server" : "nginx\/1.9.12",
           "Content-Type" : "application\/json",
@@ -12,7 +12,7 @@
           "Access-Control-Allow-Methods" : "GET, POST, OPTIONS",
           "Access-Control-Allow-Credentials" : "true",
           "Access-Control-Max-Age" : "1728000",
-          "Date" : "Mon, 04 Apr 2016 14:03:30 GMT",
+          "Date" : "Mon, 04 Apr 2016 19:16:01 GMT",
           "Access-Control-Allow-Headers" : "X-Requested-With",
           "Content-Length" : "1",
           "Cache-Control" : "no-cache, no-store",
@@ -21,7 +21,7 @@
       },
       "request" : {
         "method" : "GET",
-        "url" : "https:\/\/api.mixpanel.com\/track\/?data=eyJldmVudCI6InRlc3QxIiwicHJvcGVydGllcyI6eyIkbW9kZWwiOiJ4ODZfNjQiLCIkbWFudWZhY3R1cmVyIjoiQXBwbGUiLCJ0b2tlbiI6IjA3ZTYwYzE1YzI2MzBkOTA0N2Q2MmFjNzc5MjAzY2FlIiwidGltZSI6MTQzNDk1NDk3NCwiJHNjcmVlbl9oZWlnaHQiOjY2NywiJHNjcmVlbl93aWR0aCI6Mzc1LCIkb3MiOiJpUGhvbmUgT1MiLCIkb3NfdmVyc2lvbiI6IjkuMyIsIm1wX2xpYiI6ImlwaG9uZSJ9fQ==&ip=1"
+        "url" : "https:\/\/api.mixpanel.com\/track\/?data=eyJwcm9wZXJ0aWVzIjp7IiRtb2RlbCI6Ing4Nl82NCIsIiRtYW51ZmFjdHVyZXIiOiJBcHBsZSIsInRva2VuIjoiMDdlNjBjMTVjMjYzMGQ5MDQ3ZDYyYWM3NzkyMDNjYWUiLCJ0aW1lIjoxNDM0OTU0OTc0LCIkc2NyZWVuX2hlaWdodCI6NjY3LCIkc2NyZWVuX3dpZHRoIjozNzUsIiRvcyI6ImlQaG9uZSBPUyIsIiRvc192ZXJzaW9uIjoiOS4zIiwibXBfbGliIjoiaXBob25lIn0sImV2ZW50IjoidGVzdDEifQ==&ip=1"
       }
     }
   ],

--- a/Mixpanel/Tests/Fixtures/tracking.json
+++ b/Mixpanel/Tests/Fixtures/tracking.json
@@ -1,18 +1,18 @@
 {
   "interactions" : [
     {
-      "recorded_at" : 1441750105.527636,
+      "recorded_at" : 1459778610.240579,
       "response" : {
         "status" : 200,
-        "url" : "https:\/\/api.mixpanel.com\/track\/?data=eyJldmVudCI6InRlc3QxIiwicHJvcGVydGllcyI6eyIkbW9kZWwiOiJ4ODZfNjQiLCIkbWFudWZhY3R1cmVyIjoiQXBwbGUiLCJ0b2tlbiI6IjA3ZTYwYzE1YzI2MzBkOTA0N2Q2MmFjNzc5MjAzY2FlIiwidGltZSI6MTQzNDk1NDk3NCwiJHNjcmVlbl9oZWlnaHQiOjY2NywiJHNjcmVlbl93aWR0aCI6Mzc1LCIkb3MiOiJpUGhvbmUgT1MiLCIkb3NfdmVyc2lvbiI6IjkuMCIsIm1wX2xpYiI6ImlwaG9uZSJ9fQ==&ip=1",
+        "url" : "https:\/\/api.mixpanel.com\/track\/?data=eyJldmVudCI6InRlc3QxIiwicHJvcGVydGllcyI6eyIkbW9kZWwiOiJ4ODZfNjQiLCIkbWFudWZhY3R1cmVyIjoiQXBwbGUiLCJ0b2tlbiI6IjA3ZTYwYzE1YzI2MzBkOTA0N2Q2MmFjNzc5MjAzY2FlIiwidGltZSI6MTQzNDk1NDk3NCwiJHNjcmVlbl9oZWlnaHQiOjY2NywiJHNjcmVlbl93aWR0aCI6Mzc1LCIkb3MiOiJpUGhvbmUgT1MiLCIkb3NfdmVyc2lvbiI6IjkuMyIsIm1wX2xpYiI6ImlwaG9uZSJ9fQ==&ip=1",
         "headers" : {
-          "Server" : "nginx\/1.9.1",
+          "Server" : "nginx\/1.9.12",
           "Content-Type" : "application\/json",
           "Access-Control-Allow-Origin" : "*",
           "Access-Control-Allow-Methods" : "GET, POST, OPTIONS",
           "Access-Control-Allow-Credentials" : "true",
           "Access-Control-Max-Age" : "1728000",
-          "Date" : "Tue, 08 Sep 2015 22:08:25 GMT",
+          "Date" : "Mon, 04 Apr 2016 14:03:30 GMT",
           "Access-Control-Allow-Headers" : "X-Requested-With",
           "Content-Length" : "1",
           "Cache-Control" : "no-cache, no-store",
@@ -21,7 +21,7 @@
       },
       "request" : {
         "method" : "GET",
-        "url" : "https:\/\/api.mixpanel.com\/track\/?data=eyJldmVudCI6InRlc3QxIiwicHJvcGVydGllcyI6eyIkbW9kZWwiOiJ4ODZfNjQiLCIkbWFudWZhY3R1cmVyIjoiQXBwbGUiLCJ0b2tlbiI6IjA3ZTYwYzE1YzI2MzBkOTA0N2Q2MmFjNzc5MjAzY2FlIiwidGltZSI6MTQzNDk1NDk3NCwiJHNjcmVlbl9oZWlnaHQiOjY2NywiJHNjcmVlbl93aWR0aCI6Mzc1LCIkb3MiOiJpUGhvbmUgT1MiLCIkb3NfdmVyc2lvbiI6IjkuMCIsIm1wX2xpYiI6ImlwaG9uZSJ9fQ==&ip=1"
+        "url" : "https:\/\/api.mixpanel.com\/track\/?data=eyJldmVudCI6InRlc3QxIiwicHJvcGVydGllcyI6eyIkbW9kZWwiOiJ4ODZfNjQiLCIkbWFudWZhY3R1cmVyIjoiQXBwbGUiLCJ0b2tlbiI6IjA3ZTYwYzE1YzI2MzBkOTA0N2Q2MmFjNzc5MjAzY2FlIiwidGltZSI6MTQzNDk1NDk3NCwiJHNjcmVlbl9oZWlnaHQiOjY2NywiJHNjcmVlbl93aWR0aCI6Mzc1LCIkb3MiOiJpUGhvbmUgT1MiLCIkb3NfdmVyc2lvbiI6IjkuMyIsIm1wX2xpYiI6ImlwaG9uZSJ9fQ==&ip=1"
       }
     }
   ],

--- a/Mixpanel/Tests/MixpanelTests.swift
+++ b/Mixpanel/Tests/MixpanelTests.swift
@@ -55,4 +55,22 @@ class MixpanelTests: XCTestCase {
 
 		waitForExpectationsWithTimeout(1, handler: nil)
 	}
+    
+    func testPeopleSet() {
+        let expectation = expectationWithDescription("Completion")
+        
+        let client = Mixpanel(token: "07e60c15c2630d9047d62ac779203cae", identifier: "1", URLSession: Session(cassetteName: "people-set"))
+        
+        let profile = [
+            "$name": "Example User",
+            "$email": "exampleuser@example.com"
+        ]
+        
+        client.people(.Set(profile)) { success in
+            XCTAssertTrue(success)
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(1, handler: nil)
+    }
 }


### PR DESCRIPTION
I've been using your client for a few months now, and needed to add support for [Mixpanel's People API](https://mixpanel.com/help/reference/http#people-analytics-updates).

Some things I did:
- bumped DVR to the newest version
- re-recorded existing test cassettes as DVR couldn't find the previous ones (please clone this branch and double check the tests pass for you!)
- wrote one test for the people API
- gently refactored the `track()` function to match it to the newly added `people()`
- I only needed support for the people API `$set` and `$add` profile operations, but I ended up adding support for all operations listed by Mixpanel's docs (they could probably use more tests)

Please let me know if you need any corrections. I did not make any breaking API changes. I tried to make the usage of the `people()` API similar to Mixpanel's official library. E.g.:

``` Objective-C
// Mixpanel's official library (Objective-C)
[mixpanel.people set:@{@"Plan": @"Premium"}];
```

``` Swift
// This library (Swift)
mixpanel.people(.Set(["Plan": "Premium"]))
```
